### PR TITLE
Allow the PPSM format

### DIFF
--- a/index.html
+++ b/index.html
@@ -137,7 +137,7 @@
           if (files.length == 1) {
             var entry = event.dataTransfer.items[0].webkitGetAsEntry();
             var file = files[0];
-            var is_pptx = file.name.match(/\.pptx/);
+            var is_pptx = (file.name.match(/\.pptx/) || file.name.match(/\.ppsm/));
 
             if (entry.isFile && is_pptx) {
               unzip(file);


### PR DESCRIPTION
PPSM is a format for Powerpoints with Macros. The XML is same, but it also contains embedded macros. Just allowed the PPSM format to go through.